### PR TITLE
added logic to access different endpoint for empty searches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "marklogic-marketing/WP-MarkLogic-Search",
+  "name": "marklogic-community/WP-MarkLogic-Search",
   "description": "Use MarkLogic for search on WordPress website.",
-  "homepage": "https://github.com/marklogic-marketing/WP-MarkLogic-Search",
+  "homepage": "https://github.com/marklogic-community/WP-MarkLogic-Search",
   "keywords": [
     "wordpress","marklogic","search"
   ],

--- a/inc/MlphpDriver.php
+++ b/inc/MlphpDriver.php
@@ -98,7 +98,7 @@ final class MlphpDriver implements Driver
         return new BulkResult($count, $errors);
     }
 
-    private function createDocument($blogId, $post, $postMeta)
+    private function createDocument($blogId, $post, $postMeta=null)
     {
         return new Document($this->client, sprintf('/%s.xml', apply_filters(
             'ml_wpsearch_document_uri',


### PR DESCRIPTION
Empty searches are better handled with a separate search endpoint. In order to use this, the endpoint name (previously sent as a string) can now be sent as an array of strings (2 max). When the search box is empty, the second name in the array is used, which sends the data to another endpoint.